### PR TITLE
Add Gabarits navigation link

### DIFF
--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -8,6 +8,7 @@ const NAV_ITEMS = [
   { href: "/", label: "Tableau de bord" },
   { href: "/transactions", label: "Transactions" },
   { href: "/journal", label: "Journal" },
+  { href: "/gabarits", label: "Gabarits" },
   { href: "/snapshots", label: "Snapshots" },
   { href: "/export", label: "Export" }
 ];


### PR DESCRIPTION
## Summary
- add a Gabarits entry in the application shell navigation menu
- rely on the existing pathname.startsWith logic to keep the Gabarits item active when browsing its section

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6a19d8b788333aeaf79818b82df7d