### PR TITLE
Add gabarits CRUD endpoints and database support

### DIFF
--- a/alembic/versions/a25935b29c0d_create_gabarits_table.py
+++ b/alembic/versions/a25935b29c0d_create_gabarits_table.py
@@ -1,0 +1,32 @@
+"""create gabarits table
+
+Revision ID: a25935b29c0d
+Revises: 0007
+Create Date: 2025-09-26 16:26:58.089621
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a25935b29c0d"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "gabarits",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("nom", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("contenu", sa.Text(), nullable=False),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("gabarits")

--- a/backend/app/api/gabarits.py
+++ b/backend/app/api/gabarits.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api import deps
+from app.models.gabarits import Gabarit
+from app.schemas.gabarits import GabaritCreate, GabaritResponse, GabaritUpdate
+
+router = APIRouter(prefix="/gabarits", tags=["gabarits"])
+
+
+@router.get("/", response_model=list[GabaritResponse])
+def list_gabarits(db: Session = Depends(deps.get_db)) -> list[Gabarit]:
+    return db.query(Gabarit).order_by(Gabarit.nom.asc()).all()
+
+
+@router.get("/{gabarit_id}", response_model=GabaritResponse)
+def get_gabarit(gabarit_id: int, db: Session = Depends(deps.get_db)) -> Gabarit:
+    gabarit = db.get(Gabarit, gabarit_id)
+    if gabarit is None:
+        raise HTTPException(status_code=404, detail="Gabarit introuvable")
+    return gabarit
+
+
+@router.post("/", response_model=GabaritResponse, status_code=201)
+def create_gabarit(payload: GabaritCreate, db: Session = Depends(deps.get_db)) -> Gabarit:
+    exists = db.query(Gabarit).filter(Gabarit.nom == payload.nom).first()
+    if exists is not None:
+        raise HTTPException(status_code=400, detail="Un gabarit avec ce nom existe déjà")
+
+    gabarit = Gabarit(
+        nom=payload.nom,
+        description=payload.description,
+        contenu=payload.contenu,
+        metadonnees=payload.metadonnees,
+    )
+    db.add(gabarit)
+    db.commit()
+    db.refresh(gabarit)
+    return gabarit
+
+
+@router.patch("/{gabarit_id}", response_model=GabaritResponse)
+def update_gabarit(
+    gabarit_id: int,
+    payload: GabaritUpdate,
+    db: Session = Depends(deps.get_db),
+) -> Gabarit:
+    gabarit = db.get(Gabarit, gabarit_id)
+    if gabarit is None:
+        raise HTTPException(status_code=404, detail="Gabarit introuvable")
+
+    data = payload.model_dump(exclude_unset=True)
+
+    if "nom" in data:
+        exists = (
+            db.query(Gabarit)
+            .filter(Gabarit.nom == data["nom"], Gabarit.id != gabarit_id)
+            .first()
+        )
+        if exists is not None:
+            raise HTTPException(status_code=400, detail="Un gabarit avec ce nom existe déjà")
+
+    for field, value in data.items():
+        setattr(gabarit, field, value)
+
+    db.add(gabarit)
+    db.commit()
+    db.refresh(gabarit)
+    return gabarit
+
+
+@router.delete("/{gabarit_id}")
+def delete_gabarit(gabarit_id: int, db: Session = Depends(deps.get_db)) -> dict[str, str]:
+    gabarit = db.get(Gabarit, gabarit_id)
+    if gabarit is None:
+        raise HTTPException(status_code=404, detail="Gabarit introuvable")
+
+    db.delete(gabarit)
+    db.commit()
+    return {"status": "ok"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,16 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
-from app.api import configuration, export, health, journal, portfolio, snapshots, transactions
+from app.api import (
+    configuration,
+    export,
+    gabarits,
+    health,
+    journal,
+    portfolio,
+    snapshots,
+    transactions,
+)
 from app.core.config import settings
 from app.core.logging import setup_logging
 from app.db import base  # noqa: F401
@@ -108,3 +117,4 @@ app.include_router(snapshots.router)
 app.include_router(journal.router)
 app.include_router(configuration.router)
 app.include_router(export.router)
+app.include_router(gabarits.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,3 +8,4 @@ from .settings import Setting  # noqa: F401
 from .fx_rates import FxRate  # noqa: F401
 from .system_logs import SystemLog  # noqa: F401
 from .account_settings import AccountSetting  # noqa: F401
+from .gabarits import Gabarit  # noqa: F401

--- a/backend/app/models/gabarits.py
+++ b/backend/app/models/gabarits.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from sqlalchemy import JSON, Column, Integer, String, Text
+
+from .base import Base
+
+
+class Gabarit(Base):
+    __tablename__ = "gabarits"
+
+    id = Column(Integer, primary_key=True, index=True)
+    nom = Column(String(255), nullable=False, unique=True)
+    description = Column(Text, nullable=True)
+    contenu = Column(Text, nullable=False)
+    metadonnees = Column("metadata", JSON, nullable=True)

--- a/backend/app/schemas/gabarits.py
+++ b/backend/app/schemas/gabarits.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class GabaritBase(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    nom: str
+    description: str | None = None
+    contenu: str
+    metadonnees: dict[str, Any] | None = None
+
+
+class GabaritCreate(GabaritBase):
+    pass
+
+
+class GabaritUpdate(BaseModel):
+    nom: str | None = None
+    description: str | None = None
+    contenu: str | None = None
+    metadonnees: dict[str, Any] | None = None
+
+
+class GabaritResponse(GabaritBase):
+    id: int

--- a/backend/tests/test_gabarits_api.py
+++ b/backend/tests/test_gabarits_api.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api import deps
+from app.api import gabarits as gabarits_api
+from app.models.base import Base
+from app.models.gabarits import Gabarit
+
+
+def _create_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestingSessionLocal = sessionmaker(bind=engine)
+    return engine, TestingSessionLocal
+
+
+def _create_app(SessionLocal):
+    app = FastAPI()
+
+    def override_get_db():
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.include_router(gabarits_api.router)
+    app.dependency_overrides[deps.get_db] = override_get_db
+    return app
+
+
+def test_gabarits_crud_flow() -> None:
+    engine, SessionLocal = _create_session()
+    try:
+        app = _create_app(SessionLocal)
+        client = TestClient(app)
+
+        response = client.post(
+            "/gabarits/",
+            json={
+                "nom": "Rapport Mensuel",
+                "description": "Synthèse des performances",
+                "contenu": "Contenu du rapport",
+                "metadonnees": {"version": 1},
+            },
+        )
+        assert response.status_code == 201
+        gabarit = response.json()
+        assert gabarit["nom"] == "Rapport Mensuel"
+        gabarit_id = gabarit["id"]
+
+        # Attempt to create a duplicate name
+        response = client.post(
+            "/gabarits/",
+            json={
+                "nom": "Rapport Mensuel",
+                "description": "Doublon",
+                "contenu": "Autre contenu",
+            },
+        )
+        assert response.status_code == 400
+
+        response = client.get("/gabarits/")
+        assert response.status_code == 200
+        payload = response.json()
+        assert len(payload) == 1
+        assert payload[0]["id"] == gabarit_id
+
+        response = client.get(f"/gabarits/{gabarit_id}")
+        assert response.status_code == 200
+        assert response.json()["contenu"] == "Contenu du rapport"
+
+        response = client.patch(
+            f"/gabarits/{gabarit_id}",
+            json={
+                "description": "Synthèse mise à jour",
+                "metadonnees": {"version": 2},
+            },
+        )
+        assert response.status_code == 200
+        updated = response.json()
+        assert updated["description"] == "Synthèse mise à jour"
+        assert updated["metadonnees"] == {"version": 2}
+
+        response = client.delete(f"/gabarits/{gabarit_id}")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+        response = client.get(f"/gabarits/{gabarit_id}")
+        assert response.status_code == 404
+    finally:
+        engine.dispose()
+
+
+def test_update_gabarit_requires_unique_name() -> None:
+    engine, SessionLocal = _create_session()
+    db = SessionLocal()
+    try:
+        db.add_all(
+            [
+                Gabarit(
+                    nom="Rapport 1",
+                    description=None,
+                    contenu="Contenu 1",
+                    metadonnees=None,
+                ),
+                Gabarit(
+                    nom="Rapport 2",
+                    description=None,
+                    contenu="Contenu 2",
+                    metadonnees=None,
+                ),
+            ]
+        )
+        db.commit()
+        db.close()
+
+        app = _create_app(SessionLocal)
+        client = TestClient(app)
+
+        response = client.patch(
+            "/gabarits/1",
+            json={"nom": "Rapport 2"},
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Un gabarit avec ce nom existe déjà"
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## Summary
- add a SQLAlchemy model for gabarits and create the associated database table
- implement CRUD endpoints and Pydantic schemas for managing gabarits
- cover the new API with tests that verify creation, update, deletion, and uniqueness validation

## Testing
- PYTHONPATH=backend pytest backend/tests/test_gabarits_api.py


------
https://chatgpt.com/codex/tasks/task_e_68d6bdbfe74c83338de75cffa513e1c6